### PR TITLE
Update user name on log in, not just sign up

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -67,6 +67,7 @@ const signUpLogin = async (req, res) => {
     });
     if (user) {
       user.accessToken = accessToken;
+      user.name = name;
       console.log(`${name} logged in`);
       user.save().then((user) => {
         req.session.user = user;


### PR DESCRIPTION
People's names may have changed from the names they had when they first logged in, after subsequent sign ons. You should not be displaying deadnames. 

This PR sets people's names on every log in and not just sign up.